### PR TITLE
Empty Parameters kept breaking upgrades

### DIFF
--- a/index.js
+++ b/index.js
@@ -781,7 +781,12 @@ function processPaths(container, containerName, options, requestBodyCache, opena
             if ((common.httpVerbs.indexOf(method) >= 0) || (method === 'x-amazon-apigateway-any-method')) {
                 let op = path[method];
 
-                if (op.parameters && Array.isArray(op.parameters)) {
+                if (op.parameters === null) {
+                    delete op.parameters;
+                    continue;
+                }
+
+                if (Array.isArray(op.parameters)) {
                     if (path.parameters) {
                         for (let param of path.parameters) {
                             if (typeof param.$ref === 'string') {

--- a/test/empty-parameters/openapi.yaml
+++ b/test/empty-parameters/openapi.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: empty parameters
+paths:
+  /health/all.json:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/test/empty-parameters/swagger.yaml
+++ b/test/empty-parameters/swagger.yaml
@@ -1,0 +1,11 @@
+swagger: '2.0'
+info:
+  version: '1.0'
+  title: empty parameters
+paths:
+  /health/all.json:
+    get:
+      parameters:
+      responses:
+        200:
+          description: OK


### PR DESCRIPTION
To be fair, swagger2openapi is honourably doing its job, but we had a few specs with empty parameters showing up. If that happens just delete it (there was nothing there in the first place)