### PR TITLE
err is not defined

### DIFF
--- a/packages/oas-resolver/index.js
+++ b/packages/oas-resolver/index.js
@@ -179,8 +179,8 @@ function resolveExternal(root, pointer, options, callback) {
                 }
                 catch (ex) {
                     if (options.verbose) console.warn(ex);
-                    if (options.promise && options.fatal) options.promise.reject(err)
-                    else throw(err);
+                    if (options.promise && options.fatal) options.promise.reject(ex)
+                    else throw(ex);
                 }
                 callback(data, target, options);
                 return data;


### PR DESCRIPTION
I was getting some YAML error and it was throwing up `err is not defined`

```
Rewriting external ref ../components/schemas/shared/meta.json as /Users/phil.sturgeon/src/id/docs/components/schemas/shared/meta.json
Rewriting external ref ../components/schemas/company.json as /Users/phil.sturgeon/src/id/docs/components/schemas/company.json
Finished internal resolution
Creating initial clone of data at #/paths/~1v3~1companies
GET /Users/phil.sturgeon/src/id/docs/paths/companies-id.yml
{ YAMLException: bad indentation of a sequence entry at line 19, column 7:
          in: query
          ^
    at generateError (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:165:10)
    at throwError (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:171:9)
    at readBlockSequence (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:935:7)
    at composeNode (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:1331:12)
    at readBlockMapping (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:1062:11)
    at composeNode (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:1332:12)
    at readBlockMapping (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:1062:11)
    at composeNode (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:1332:12)
    at readDocument (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:1492:3)
    at loadDocuments (/Users/phil.sturgeon/src/speccy/node_modules/js-yaml/lib/js-yaml/loader.js:1548:5)
  name: 'YAMLException',
  reason: 'bad indentation of a sequence entry',
  mark:
   Mark {
     name: null,
     buffer:
      'parameters:\n  - name: company_id\n    in: path\n    description: Company UUID\n    example: \'6bc8bb80-1e32-0136-eb32-0242ac11530c\'\n    schema:\n      type: string\n      format: UUID\n    required: true\n\nget:\n  summary: Get Company\n  description: Returns Specific Company\n  tags:\n    - Companies\n  operationId: getCompanyById\n  parameters:\n     - name: include\n      in: query\n      description:\n        Including \'full\' returns all possible values.\n      schema:\n        type: string\n        default: full\n        enum:\n          - full      \n          - locations\n          - primary_member\n          - enterprise\n          - printer_info\n          - timestamps\n          - aliases\n  responses:\n    200:\n      description: OK\n      content:\n        application/json:\n          schema:\n            type: object\n            properties:\n              meta:\n                $ref: \'../components/schemas/shared/meta.json\'\n              result:\n                $ref: \'../components/schemas/company.json\'\n\npatch:\n  summary: Update Company by ID\n  description: Updates the specified Company\n  tags:\n    - Companies\n  operationId: patchCompanyById\n  requestBody:\n    $ref: \'../components/requestBodies/companies.yml\'\n  parameters:\n    - name: company_params\n      in: query\n      description: company parameters\n      schema:\n        type: object\n  responses:\n    200:\n      description: OK\n      content:\n        application/json:\n          schema:\n            type: object\n            properties:\n              meta:\n                $ref: \'../components/schemas/shared/meta.json\'\n              result:\n                $ref: \'../components/schemas/company.json\'\n\u0000',
     position: 361,
     line: 18,
     column: 6 },
  message:
   'bad indentation of a sequence entry at line 19, column 7:\n          in: query\n          ^' }
ReferenceError: err is not defined
    at /Users/phil.sturgeon/src/speccy/node_modules/oas-resolver/index.js:215:26
ReferenceError: err is not defined
    at /Users/phil.sturgeon/src/speccy/node_modules/oas-resolver/index.js:215:26
err is not defined
```