### PR TITLE
Keep description when schema contains a $ref

### DIFF
--- a/packages/oas-schema-walker/index.js
+++ b/packages/oas-schema-walker/index.js
@@ -11,7 +11,7 @@
 * @return the state object suitable for use in walkSchema
 */
 function getDefaultState() {
-    return { depth: 0, seen: new WeakMap(), top: true, combine: false };
+    return { depth: 0, seen: new WeakMap(), top: true, combine: false, allowRefSiblings: false };
 }
 
 /**
@@ -28,7 +28,7 @@ function walkSchema(schema, parent, state, callback) {
     if ((schema === null) || (typeof schema === 'undefined')) return schema;
     if (typeof schema.$ref !== 'undefined') {
         let temp = {$ref:schema.$ref};
-        if (schema.description) {
+        if (state.allowRefSiblings && schema.description) {
             temp.description = schema.description;
         }
         callback(temp,parent,state);

--- a/packages/oas-schema-walker/index.js
+++ b/packages/oas-schema-walker/index.js
@@ -28,6 +28,9 @@ function walkSchema(schema, parent, state, callback) {
     if ((schema === null) || (typeof schema === 'undefined')) return schema;
     if (typeof schema.$ref !== 'undefined') {
         let temp = {$ref:schema.$ref};
+        if (schema.description) {
+            temp.description = schema.description;
+        }
         callback(temp,parent,state);
         return temp; // all other properties SHALL be ignored
     }


### PR DESCRIPTION
I know [the comment](https://github.com/Mermade/oas-kit/blob/master/packages/oas-schema-walker/index.js#L32) says that all other properties shall be ignored, but it seems inconsistent that we strip out descriptions for attributes that contain a $ref when an array with items of $ref can have descriptions.

<img width="455" alt="screen shot 2018-08-03 at 1 56 56 pm" src="https://user-images.githubusercontent.com/1416762/43660641-3f9ab9d4-9725-11e8-9181-bfccc99bb1af.png">

So I check if the schema contains a description when there is a $ref and add it to the object to be returned. 

IMO, this provides value over just depending on the description of the entity because a common entity used in different ways could have different descriptions based on where it is being used.