### PR TITLE
chore: add "repository" and "bugs" to all package.json files

### DIFF
--- a/packages/oas-kit-common/package.json
+++ b/packages/oas-kit-common/package.json
@@ -17,5 +17,12 @@
     "js-yaml": "^3.12.0"
   },
   "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mermade/oas-kit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mermade/oas-kit/issues"
+  },
   "gitHead": "da527220c78530e836c33f77178493aab93d385c"
 }

--- a/packages/oas-linter/package.json
+++ b/packages/oas-linter/package.json
@@ -18,5 +18,12 @@
     "js-yaml": "^3.12.0",
     "should": "^13.2.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mermade/oas-kit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mermade/oas-kit/issues"
+  },
   "gitHead": "da527220c78530e836c33f77178493aab93d385c"
 }

--- a/packages/oas-resolver/package.json
+++ b/packages/oas-resolver/package.json
@@ -25,5 +25,12 @@
     "reftools": "^1.0.3",
     "yargs": "^12.0.2"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mermade/oas-kit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mermade/oas-kit/issues"
+  },
   "gitHead": "da527220c78530e836c33f77178493aab93d385c"
 }

--- a/packages/oas-schema-walker/package.json
+++ b/packages/oas-schema-walker/package.json
@@ -15,5 +15,12 @@
   ],
   "author": "Mike Ralphson",
   "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mermade/oas-kit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mermade/oas-kit/issues"
+  },
   "gitHead": "da527220c78530e836c33f77178493aab93d385c"
 }

--- a/packages/oas-validator/package.json
+++ b/packages/oas-validator/package.json
@@ -26,5 +26,12 @@
     "reftools": "^1.0.3",
     "should": "^13.2.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mermade/oas-kit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mermade/oas-kit/issues"
+  },
   "gitHead": "5cbeab49334ebe18c117764d086e1cfe7d708e97"
 }

--- a/packages/reftools/package.json
+++ b/packages/reftools/package.json
@@ -31,6 +31,10 @@
   ],
   "author": "Mike Ralphson",
   "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mermade/oas-kit.git"
+  },
   "bugs": {
     "url": "https://github.com/mermade/oas-kit/issues"
   },

--- a/packages/swagger2openapi/package.json
+++ b/packages/swagger2openapi/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/Mermade/oas-kit.git",
     "type": "git"
   },
+  "bugs": {
+    "url": "https://github.com/mermade/oas-kit/issues"
+  },
   "author": "Mike Ralphson <mike.ralphson@gmail.com>",
   "license": "BSD-3-Clause",
   "dependencies": {


### PR DESCRIPTION
I noticed that some packages from oas-kit, most notably https://www.npmjs.com/package/oas-validator, don't provide information about the GitHub repository where the source code can be found & bugs reported.

In this pull request, I am adding "repository" and "bugs" fields where they were missing.