### PR TITLE
Missing Path linter entry in Validate Sync

### DIFF
--- a/packages/oas-validator/index.js
+++ b/packages/oas-validator/index.js
@@ -1009,12 +1009,11 @@ function validateSync(openapi, options, callback) {
         if (options.lint) options.linter('externalDocs',openapi.externalDocs,'externalDocs',options);
         options.context.pop();
     }
-        
+
     if (typeof openapi.paths !== 'undefined'){
         if (options.lint) options.linter('paths',openapi.paths,'paths',options);
     }
-        
-        
+
     if (typeof openapi.tags !== 'undefined') {
         should(openapi.tags).be.an.Array();
         contextAppend(options, 'tags');

--- a/packages/oas-validator/index.js
+++ b/packages/oas-validator/index.js
@@ -860,7 +860,7 @@ function checkPathItem(pathItem, path, openapi, options) {
         options.context.pop();
     }
     if (options.lint) options.linter('pathItem',pathItem,path,options);
-    if (options.lint) options.linter('paths',openapi.paths,path,options);
+    //if (options.lint) options.linter('paths',openapi.paths,path,options);
     return true;
 }
 
@@ -1010,7 +1010,12 @@ function validateSync(openapi, options, callback) {
         if (options.lint) options.linter('externalDocs',openapi.externalDocs,'externalDocs',options);
         options.context.pop();
     }
-
+        
+    if (typeof openapi.paths !== 'undefined'){
+        if (options.lint) options.linter('paths',openapi.paths,'paths',options);
+    }
+        
+        
     if (typeof openapi.tags !== 'undefined') {
         should(openapi.tags).be.an.Array();
         contextAppend(options, 'tags');

--- a/packages/oas-validator/index.js
+++ b/packages/oas-validator/index.js
@@ -860,7 +860,6 @@ function checkPathItem(pathItem, path, openapi, options) {
         options.context.pop();
     }
     if (options.lint) options.linter('pathItem',pathItem,path,options);
-    //if (options.lint) options.linter('paths',openapi.paths,path,options);
     return true;
 }
 


### PR DESCRIPTION
I was confronted with a 'Paths' rule that was called for each 'PathItem'  which is not logic. I updated the file so that it:
1. Calls the 'Paths' linter from the same position as it calls all the other components of a swagger
2. It does not call the 'Paths' linter from within each PathItem

This will allows speccy users to create rules on the Path object and have it run only once.