### PR TITLE
allow original lint rules to be disabled, fixes #114

### DIFF
--- a/packages/oas-linter/index.js
+++ b/packages/oas-linter/index.js
@@ -26,13 +26,12 @@ function applyRules(ruleData,parent) {
         if (!Array.isArray(rule.object)) rule.object = [ rule.object ];
         if (rule.truthy && !Array.isArray(rule.truthy)) rule.truthy = [ rule.truthy ];
     }
-    newRules = newRules.filter(function(e){ return !e.disabled; });
 
     let hash = new Map();
     rules.concat(newRules).forEach(function(rule) {
         hash.set(rule.name, Object.assign(hash.get(rule.name) || {}, rule));
     });
-    rules = Array.from(hash.values());
+    rules = Array.from(hash.values()).filter(function(e){ return !e.disabled; });
     results = [];
     return rules;
 }


### PR DESCRIPTION
disabled rules were filtered out prior to combining them with
existing rules, which made it not possible to disable a lint rule
defined in the original rules yaml file. now, we'll filter out the
disabled rules after combining them with existing rules, so
original rules can be disabled from a new rules yaml file, rather than
only from the lintSkip option.

@MikeRalphson 