### PR TITLE
[#125] Call linter for securityScheme objects

### DIFF
--- a/packages/oas-validator/index.js
+++ b/packages/oas-validator/index.js
@@ -1131,6 +1131,7 @@ function validateSync(openapi, options, callback) {
             else {
                 should(scheme).not.have.property('openIdConnectUrl');
             }
+            if (options.lint) options.linter('securityScheme',scheme,s,options);
             options.context.pop();
         }
         options.context.pop();


### PR DESCRIPTION
Fix for #125, making sure the linter is called for each securitySchema object.