### PR TITLE
linter; check if property is undefined for truthy rules, fixes #124

### DIFF
--- a/packages/oas-linter/index.js
+++ b/packages/oas-linter/index.js
@@ -83,6 +83,7 @@ function lint(objectName,object,key,options) {
                 for (let property of rule.truthy) {
                     ensure(rule, () => {
                         should(object).have.property(property);
+                        should(object[property]).not.be.undefined();
                         should(object[property]).not.be.empty();
                     });
                 }


### PR DESCRIPTION
For some programatic uses of the linter, properties could have
explicit undefined values. This causes should(value).not.be.empty()
to throw the error: there is no type adaptor `forEach` for undefined.
So, we'll check if values are undefined prior to checking if they
are empty.

@MikeRalphson 