### PR TITLE
Adds propogation of response key to the linter

### DIFF
--- a/packages/oas-validator/index.js
+++ b/packages/oas-validator/index.js
@@ -543,7 +543,7 @@ function checkHeader(header, contextServers, openapi, options) {
     if (options.lint) options.linter('header',header,'header',options);
 }
 
-function checkResponse(response, contextServers, openapi, options) {
+function checkResponse(response, key, contextServers, openapi, options) {
     should(response).not.be.null();
     if (typeof response.$ref !== 'undefined') {
         let ref = response.$ref;
@@ -580,7 +580,7 @@ function checkResponse(response, contextServers, openapi, options) {
         }
         options.context.pop();
     }
-    if (options.lint) options.linter('response',response,'response',options);
+    if (options.lint) options.linter('response',response,key,options);
 }
 
 function checkParam(param, index, path, contextServers, openapi, options) {
@@ -782,7 +782,7 @@ function checkPathItem(pathItem, path, openapi, options) {
                 if (!r.startsWith('x-')) {
                     contextAppend(options, r);
                     let response = op.responses[r];
-                    checkResponse(response, contextServers, openapi, options);
+                    checkResponse(response, r, contextServers, openapi, options);
                     options.context.pop();
                 }
             }
@@ -1222,7 +1222,7 @@ function validateSync(openapi, options, callback) {
         for (let r in openapi.components.responses) {
             options.context.push('#/components/responses/' + r);
             should(validateComponentName(r)).be.equal(true, 'component name invalid');
-            checkResponse(openapi.components.responses[r], contextServers, openapi, options);
+            checkResponse(openapi.components.responses[r], r, contextServers, openapi, options);
             options.context.pop();
         }
         options.context.pop();


### PR DESCRIPTION
In order to achieve the request done by @bottoy in #128, validating if the key of the response is an integer, I needed to change the call to the linter.

Due to this change, the following rule is working:

```yaml
- name: response-must-be-integer
  object: response
  description: response must be an valid HTTP status code
  pattern:
    property: "$key"
    value: "^([0-9])*$"
```