### PR TITLE
Removed the trailing / as the PathItem starts with a '/' already

### DIFF
--- a/packages/oas-validator/index.js
+++ b/packages/oas-validator/index.js
@@ -1156,7 +1156,7 @@ function validateSync(openapi, options, callback) {
     let paths = {};
 
     for (let p in openapi.paths) {
-        options.context.push('#/paths/' + jptr.jpescape(p));
+        options.context.push('#/paths' + jptr.jpescape(p));
         if (!p.startsWith('x-')) {
             should(p).startWith('/');
             should(p).not.containEql('?');


### PR DESCRIPTION
When printing the context I noticed this typo in the Path construction. According to the standard the PathItem must start with a / so the trailing one is not needed.