### PR TITLE
Testcase for #145

### DIFF
--- a/test/s2o-test/issue145/openapi.yaml
+++ b/test/s2o-test/issue145/openapi.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  version: "1.0"
+  title: Issue 145 Test v1
+  description: "This is a testcase re: a referenced form param which is a string array."
+paths:
+  /v1/formtest1:
+    post:
+      operationId: formTest1
+      summary: Form parameter test 1
+      description: Form param is a referenced parameter.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                referenced_form_param:
+                  description: Referenced form param
+                  type: array
+                  items:
+                    type: string
+              required:
+                - referenced_form_param
+      responses:
+        "201":
+          description: Successful request.
+        "400":
+          description: Invalid request.
+  /v1/formtest2:
+    post:
+      operationId: formTest2
+      summary: Form parameter test 2
+      description: Form param is defined inline
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                inline_form_param:
+                  description: Inline form param.
+                  type: array
+                  items:
+                    type: string
+              required:
+                - inline_form_param
+      responses:
+        "201":
+          description: Successful request.
+        "400":
+          description: Invalid request.
+servers:
+  - url: /issue145/api

--- a/test/s2o-test/issue145/options.yaml
+++ b/test/s2o-test/issue145/options.yaml
@@ -1,0 +1,1 @@
+patch: true

--- a/test/s2o-test/issue145/swagger.yaml
+++ b/test/s2o-test/issue145/swagger.yaml
@@ -1,0 +1,50 @@
+swagger: '2.0'
+basePath: /issue145/api
+info:
+  version: '1.0'
+  title: 'Issue 145 Test v1'
+  description: 'This is a testcase re: a referenced form param which is a string array.'
+paths:
+  /v1/formtest1:
+    post:
+      operationId: formTest1
+      summary: 'Form parameter test 1'
+      description: 'Form param is a referenced parameter.'
+      consumes:
+        - multipart/form-data
+      parameters:
+        - $ref: '#/parameters/StringArrayFormParam'
+      responses:
+        '201':
+          description: 'Successful request.'
+        '400':
+          description: 'Invalid request.'
+  /v1/formtest2:
+    post:
+      operationId: formTest2
+      summary: 'Form parameter test 2'
+      description: 'Form param is defined inline'
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: inline_form_param
+          in: formData
+          description: 'Inline form param.'
+          required: true
+          type: array
+          items:
+            type: string
+      responses:
+        '201':
+          description: 'Successful request.'
+        '400':
+          description: 'Invalid request.'
+parameters:
+  StringArrayFormParam:
+    name: referenced_form_param
+    in: formData
+    description: 'Referenced form param'
+    required: true
+    type: array
+    items:
+      type: string


### PR DESCRIPTION
The testcase contained in this PR demonstrates the problem reported in #145.
Another secondary problem is the fact that if I run s2o without the -p option, the conversion fails with only 
"name: S2OError" printed and no output file created.   Adding the -p option allows the conversion to proceed, so there's some sort of issue with the input swagger.yaml file (I assume), but s2o is not properly displaying an error message to indicate what the problem is.
