### PR TITLE
Two small fixes for swagger2openapi's x-ms-parameterized-host conversion

### DIFF
--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -1421,7 +1421,7 @@ function convertObj(swagger, options, callback) {
         if (swagger['x-ms-parameterized-host']) {
             let xMsPHost = swagger['x-ms-parameterized-host'];
             let server = {};
-            server.url = xMsPHost.hostTemplate;
+            server.url = xMsPHost.hostTemplate + (swagger.basePath ? swagger.basePath : '');
             server.variables = {};
             for (let msp in xMsPHost.parameters) {
                 let param = xMsPHost.parameters[msp];

--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -1445,7 +1445,17 @@ function convertObj(swagger, options, callback) {
                 }
             }
             if (!openapi.servers) openapi.servers = [];
-            openapi.servers.push(server);
+            if (xMsPHost.useSchemePrefix === false) {
+                // The server URL already includes a protocol scheme
+                openapi.servers.push(server);
+            } else {
+                // Define this server once for each given protocol scheme
+                swagger.schemes.forEach((scheme) => {
+                    openapi.servers.push(
+                        Object.assign({}, server, { url: scheme + '://' + server.url })
+                    )
+                });
+            }
             delete openapi['x-ms-parameterized-host'];
         }
 


### PR DESCRIPTION
Right now, the generated server URLs are missing two things:

* The protocol scheme (except where `useSchemePrefix` is set to false)
* The base path

As an example, compare [the Azure Vision v1 spec](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/cognitiveservices/data-plane/ComputerVision/stable/v1.0/ComputerVision.json#L20-L27) with the URLs from [the Vision v1 docs](https://westus.dev.cognitive.microsoft.com/docs/services/56f91f2d778daf23d8ec6739/operations/56f91f2e778daf14a499e1fa).

The docs use URLs like `https://[location].api.cognitive.microsoft.com/vision/v1.0/analyze`.

Converting the specs with swagger2openapi at the moment though gives a server URL of just `{AzureRegion}.api.cognitive.microsoft.com`, followed by paths like `/analyze`. See https://unpkg.com/openapi-directory@1.0.1/api/azure.com/cognitiveservices-ComputerVision.json for an example converted with the current codebase.