### PR TITLE
Updates rules to allow escape chars

### DIFF
--- a/packages/oas-linter/rules.yaml
+++ b/packages/oas-linter/rules.yaml
@@ -60,7 +60,7 @@ rules:
     property: $ref
     omit: '#'
     split: /
-    value: '^[a-zA-Z0-9\.\-_]+$'
+    value: '^(?:[a-zA-Z0-9\.\-_{}]|(?:~[01]))+$'
 - name: no-script-tags-in-markdown
   object: '*'
   description: markdown descriptions should not contain <script> tags


### PR DESCRIPTION
I'm not sure if this was the intent or not. The rule mentions "the spec", but I'm not sure exactly which spec it is referring to. ~1 and ~0 are valid OpenAPI escape characters & I can't see anything in the URL RFC that would disallow them. I'm using the OAS Resolver to resolve a external rules and it keeps making reference that contain these characters, which the linter then doesn't like.

I've modified the regex to include both the escape characters & the braces found in path parameters.