### PR TITLE
swagger2openapi: Support parsing yaml merge keys

### DIFF
--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -1518,7 +1518,7 @@ function convertStr(str, options, callback) {
         }
         catch (ex) {
             try {
-                obj = yaml.parse(str, { schema: 'core' });
+                obj = yaml.parse(str, { schema: 'core', merge:true });
                 options.sourceYaml = true;
                 options.text = str;
             }

--- a/packages/swagger2openapi/oas-validate.js
+++ b/packages/swagger2openapi/oas-validate.js
@@ -224,7 +224,7 @@ function* check(file, force, expectFailure) {
             }
             catch (ex) {
                 try {
-                    src = yaml.parse(srcStr, { schema: 'core' });
+                    src = yaml.parse(srcStr, { schema: 'core', merge: true });
                 }
                 catch (ex) {
                     let warning = 'Could not parse file ' + file + '\n' + ex.message;

--- a/test/s2o-test/merge-key/openapi.yaml
+++ b/test/s2o-test/merge-key/openapi.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  version: "1.0"
+  title: Demo API
+x-DefaultParameters:
+  parameters:
+    - $ref: "#/components/parameters/RequestIdParam"
+paths:
+  /test:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/RequestIdParam"
+      responses:
+        "200":
+          description: OK
+components:
+  parameters:
+    RequestIdParam:
+      name: X-Request-ID
+      in: header
+      schema:
+        type: string

--- a/test/s2o-test/merge-key/swagger.yaml
+++ b/test/s2o-test/merge-key/swagger.yaml
@@ -1,0 +1,19 @@
+swagger: 2.0
+info:
+  version: '1.0'
+  title: Demo API
+x-DefaultParameters: &DEFAULT_HEADERS
+  parameters:
+  - $ref: '#/parameters/RequestIdParam'
+paths:
+  /test:
+    get:
+      <<: *DEFAULT_HEADERS
+      responses:
+        200:
+          description: OK
+parameters:
+  RequestIdParam:
+    name: X-Request-ID
+    in: header
+    type: string

--- a/test/s2o.test.js
+++ b/test/s2o.test.js
@@ -17,9 +17,6 @@ describe('Converter tests', () => {
 tests.forEach((test) => {
     describe(test, () => {
         it('should match expected output', (done) => {
-            const swagger = yaml.parse(fs.readFileSync(path.join(__dirname, 's2o-test', test, 'swagger.yaml'),'utf8'),{schema:'core'});
-            const openapi = yaml.parse(fs.readFileSync(path.join(__dirname, 's2o-test', test, 'openapi.yaml'),'utf8'),{schema:'core'});
-
             let options = {};
             try {
                 options = yaml.parse(fs.readFileSync(path.join(__dirname, 's2o-test', test, 'options.yaml'),'utf8'),{schema:'core'});
@@ -27,9 +24,10 @@ tests.forEach((test) => {
             }
             catch (ex) {}
 
-            swagger2openapi.convertObj(swagger, options, (err, result) => {
+            swagger2openapi.convertFile(path.join(__dirname, 's2o-test', test, 'swagger.yaml'), options, (err, result) => {
                 if (err) return done(err);
 
+                const openapi = yaml.parse(fs.readFileSync(path.join(__dirname, 's2o-test', test, 'openapi.yaml'),'utf8'),{schema:'core'});
                 assert.deepEqual(result.openapi, openapi);
 
                 return done();


### PR DESCRIPTION
Enable support for parsing yaml with `<<` merge keys.

Reference: [YAML options](https://eemeli.org/yaml/#options)