### PR TITLE
Added droprefs command option, so we can leave some $ref alone

### DIFF
--- a/packages/oas-resolver/index.js
+++ b/packages/oas-resolver/index.js
@@ -79,16 +79,20 @@ function resolveAllFragment(obj, context, src, parentPath, base, options) {
                     }
                 }
                 else if (baseUrl.protocol) {
-                    let newRef = url.resolve(base,obj[key]).toString();
-                    if (options.verbose>1) console.warn(common.colour.yellow+'Rewriting external url ref',obj[key],'as',newRef,common.colour.normal);
-                    obj['x-miro'] = obj[key];
-                    obj[key] = newRef;
+                    if( !options.dropRefs || obj[key].toString().match(options.dropRefs) == null) {
+                        let newRef = url.resolve(base,obj[key]).toString();
+                        if (options.verbose>1) console.warn(common.colour.yellow+'Rewriting external url ref',obj[key],'as',newRef,common.colour.normal);
+                        obj['x-miro'] = obj[key];
+                        obj[key] = newRef;
+                    }
                 }
                 else if (!obj['x-miro']) {
-                    let newRef = url.resolve(base,obj[key]).toString();
-                    if (options.verbose>1) console.warn(common.colour.yellow+'Rewriting external ref',obj[key],'as',newRef,common.colour.normal);
-                    obj['x-miro'] = obj[key]; // we use x-miro as a flag so we don't do this > once
-                    obj[key] = newRef;
+                    if ( !options.dropRefs || obj[key].toString().match(options.dropRefs) == null) {
+                        let newRef = url.resolve(base,obj[key]).toString();
+                        if (options.verbose>1) console.warn(common.colour.yellow+'Rewriting external ref',obj[key],'as',newRef,common.colour.normal);
+                        obj['x-miro'] = obj[key]; // we use x-miro as a flag so we don't do this > once
+                        obj[key] = newRef;
+                    }
                 }
             }
         });
@@ -270,6 +274,10 @@ function scanExternalRefs(options) {
         function inner(obj,key,state){
             if (obj[key] && isRef(obj[key],'$ref')) {
                 let $ref = obj[key].$ref;
+
+                if (options.dropRefs && $ref.match(options.dropRefs) != null) {
+                    if (options.verbose>1) console.warn(common.colour.yellow+'Dropped reference '+$ref+common.colour.normal);
+                } else
                 if (!$ref.startsWith('#')) { // is external
 
                     let $extra = '';

--- a/packages/oas-resolver/package-lock.json
+++ b/packages/oas-resolver/package-lock.json
@@ -1,9 +1,17 @@
 {
 	"name": "oas-resolver",
-	"version": "2.2.0",
+	"version": "2.2.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+			"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+			"requires": {
+				"regenerator-runtime": "^0.13.2"
+			}
+		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -264,9 +272,14 @@
 			}
 		},
 		"reftools": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/reftools/-/reftools-1.0.6.tgz",
-			"integrity": "sha512-90hAAFzgfPzvg4bdS/gSioz753f3mTD1gQOys2xZ169mfpw+3B4+OLEPAnMI09DuWnk53i7Jgoo0sRAGHVAH4A=="
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/reftools/-/reftools-1.0.8.tgz",
+			"integrity": "sha512-hERpM8J+L0q8dzKFh/QqcLlKZYmTgzGZM7m8b1ptS66eg4NA/iMPm7GNw3TKZ876ndVjGpiLt0BCIfAWsUgwGg=="
+		},
+		"regenerator-runtime": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -399,9 +412,12 @@
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yaml": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.3.1.tgz",
-			"integrity": "sha512-2AG732tOqaovhv9HNm39BjaEnEDaHssbAxh4atw521ohOqL4X8JHjcbyf2W+dYSVl6zG8/Ayd1a1J36k8eJQZw=="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
+			"integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
+			"requires": {
+				"@babel/runtime": "^7.4.5"
+			}
 		},
 		"yargs": {
 			"version": "12.0.5",

--- a/packages/oas-resolver/package.json
+++ b/packages/oas-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas-resolver",
-  "version": "2.2.5 (StueyNZ)",
+  "version": "2.2.5",
   "description": "Resolve external $refs in OpenAPI (swagger) 2.0 / 3.x definitions",
   "main": "index.js",
   "scripts": {

--- a/packages/oas-resolver/package.json
+++ b/packages/oas-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas-resolver",
-  "version": "2.2.5",
+  "version": "2.2.5 (StueyNZ)",
   "description": "Resolve external $refs in OpenAPI (swagger) 2.0 / 3.x definitions",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "node-fetch-h2": "^2.3.0",
     "oas-kit-common": "^1.0.7",
     "reftools": "^1.0.8",
-    "yaml": "^1.3.1",
+    "yaml": "^1.6.0",
     "yargs": "^12.0.5"
   },
   "repository": {

--- a/packages/oas-resolver/resolve.js
+++ b/packages/oas-resolver/resolve.js
@@ -23,6 +23,8 @@ let argv = require('yargs')
     .default('verbose',2)
     .alias('v','verbose')
     .describe('verbose','increase verbosity')
+    .string('droprefs')
+    .describe('droprefs', 'regexp for $refs to be left unresolved')
     .demand(1)
     .argv;
 
@@ -33,6 +35,8 @@ let options = {resolve: true};
 options.verbose = argv.verbose;
 if (argv.quiet) options.verbose = options.verbose - argv.quiet;
 options.fatal = true;
+
+options.dropRefs = argv.droprefs ? new RegExp(argv.droprefs, 'g') : null;
 
 if (filespec.startsWith('https')) options.agent = new https.Agent({ keepAlive: true })
 else if (filespec.startsWith('http')) options.agent = new http.Agent({ keepAlive: true });


### PR DESCRIPTION
 - Updated yaml library to `v1.6.0` as old versions weren't coping with inline json in the yaml very well.
-  Added `droprefs` command option; needed to use a regexp to selectively leave some `$ref`s unresolved.