### PR TITLE
Adding support for converting definition schemas that are escaped

### DIFF
--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -212,7 +212,9 @@ function fixupRefs(obj, key, state) {
         else if (obj[key].startsWith('#/definitions/')) {
             //only the first part of a schema component name must be sanitised
             let keys = obj[key].replace('#/definitions/', '').split('/');
-            let newKey = componentNames.schemas[decodeURIComponent(keys[0])]; // lookup, resolves a $ref
+            const ref = jptr.jpunescape(keys[0]);
+
+            let newKey = componentNames.schemas[decodeURIComponent(ref)]; // lookup, resolves a $ref
             if (newKey) {
                 keys[0] = newKey;
             }

--- a/test/s2o-test/issue215/openapi.yaml
+++ b/test/s2o-test/issue215/openapi.yaml
@@ -1,0 +1,50 @@
+openapi: '3.0.0'
+info:
+  version: '1.0'
+  title: API
+paths:
+  /post:
+    post:
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Random_Request'
+        description: Random body.
+        required: true
+      responses:
+        204:
+          description: No Content.
+        400:
+          description: Bad request.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error_400'
+components:
+  schemas:
+    Random_Request:
+      type: object
+      properties:
+        random_phone_number:
+          description: Some string number.
+          type: string
+          example: "0681924019"
+        other_random_phone_number:
+          description: Some string number.
+          type: string
+          example: "681924019"
+      required:
+        - random_phone_number
+    Error_400:
+      type: object
+      properties:
+        code:
+          type: string
+          example: "400"
+        label:
+          type: string
+          example: Bad Request
+        description:
+          type: string
+          example: Property "random_date" is required

--- a/test/s2o-test/issue215/swagger.yaml
+++ b/test/s2o-test/issue215/swagger.yaml
@@ -1,0 +1,46 @@
+swagger: '2.0'
+info:
+  version: '1.0'
+  title: API
+paths:
+  /post:
+    post:
+      parameters:
+        - name: body
+          description: Random body.
+          in: body
+          schema:
+            $ref: '#/definitions/Random~1Request'
+          required: true
+      responses:
+        204:
+          description: No Content.
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/Error~1400'
+definitions:
+  Random/Request:
+    type: object
+    properties:
+      random_phone_number:
+        description: Some string number.
+        type: string
+        example: "0681924019"
+      other_random_phone_number:
+        description: Some string number.
+        type: string
+        example: "681924019"
+    required: [random_phone_number]
+  Error/400:
+    type: object
+    properties:
+      code:
+        type: string
+        example: "400"
+      label:
+        type: string
+        example: Bad Request
+      description:
+        type: string
+        example: Property "random_date" is required


### PR DESCRIPTION
Previously, if a `$ref` `definition` JSON pointer was escaped with `~1` or `~0`, like `#/definitions/Random~1Request`, s2o would fail out with the following error:

```
Could not resolve reference #/definitions/Random~1Request
```

This updates the handling of `definition` conversions to account for this use case.