### PR TITLE
Bump yargs to fix https://www.sourceclear.com/vulnerability-database/security/prototype-pollution/javascript/sid-22715

### DIFF
--- a/packages/oas-resolver/package-lock.json
+++ b/packages/oas-resolver/package-lock.json
@@ -13,154 +13,82 @@
 			}
 		},
 		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+			"version": "4.1.0",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"camelcase": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+			"version": "5.3.1",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
 		},
 		"cliui": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"version": "5.0.0",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
 			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
 			}
 		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-		},
-		"cross-spawn": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
 			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"color-name": "1.1.3"
 			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"decamelize": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
-		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"requires": {
-				"once": "^1.4.0"
-			}
-		},
-		"execa": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-			"requires": {
-				"cross-spawn": "^6.0.0",
-				"get-stream": "^4.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			}
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
 		},
 		"find-up": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
 		},
 		"get-caller-file": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-		},
-		"get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"requires": {
-				"pump": "^3.0.0"
-			}
-		},
-		"invert-kv": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+			"version": "2.0.5",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-		},
-		"lcid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-			"requires": {
-				"invert-kv": "^2.0.0"
-			}
 		},
 		"locate-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
-		},
-		"map-age-cleaner": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"requires": {
-				"p-defer": "^1.0.0"
-			}
-		},
-		"mem": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-			"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
-			"requires": {
-				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^1.0.0",
-				"p-is-promise": "^2.0.0"
-			}
-		},
-		"mimic-fn": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-		},
-		"nice-try": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"node-fetch-h2": {
 			"version": "2.3.0",
@@ -177,91 +105,31 @@
 				}
 			}
 		},
-		"npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"requires": {
-				"path-key": "^2.0.0"
-			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"os-locale": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-			"requires": {
-				"execa": "^1.0.0",
-				"lcid": "^2.0.0",
-				"mem": "^4.0.0"
-			}
-		},
-		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-		},
-		"p-is-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
-		},
 		"p-limit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+			"version": "2.2.2",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-limit/-/p-limit-2.2.2.tgz",
+			"integrity": "sha1-YSebZ3IfUoeqHBOpp/u8SMkpGx4=",
 			"requires": {
 				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
 		},
 		"p-try": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+			"version": "2.2.0",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
 		},
 		"path-exists": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-exists/-/path-exists-3.0.0.tgz",
 			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-		},
-		"path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-		},
-		"pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
 		},
 		"regenerator-runtime": {
 			"version": "0.13.5",
@@ -270,128 +138,56 @@
 		},
 		"require-directory": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-		},
-		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "2.0.0",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
-		"shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"requires": {
-				"shebang-regex": "^1.0.0"
-			}
-		},
-		"shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-		},
-		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "3.1.0",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/string-width/-/string-width-3.1.0.tgz",
+			"integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
 			"requires": {
+				"emoji-regex": "^7.0.1",
 				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"strip-ansi": "^5.1.0"
 			}
 		},
 		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"version": "5.2.0",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
 			"requires": {
-				"ansi-regex": "^3.0.0"
-			}
-		},
-		"strip-eof": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-		},
-		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"requires": {
-				"isexe": "^2.0.0"
+				"ansi-regex": "^4.1.0"
 			}
 		},
 		"which-module": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wrap-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"version": "5.1.0",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
 			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"y18n": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
 		},
 		"yaml": {
 			"version": "1.8.3",
@@ -402,28 +198,26 @@
 			}
 		},
 		"yargs": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"version": "13.3.2",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs/-/yargs-13.3.2.tgz",
+			"integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.2.0",
+				"cliui": "^5.0.0",
 				"find-up": "^3.0.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^3.0.0",
+				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
+				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
+				"string-width": "^3.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^11.1.1"
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.1.2"
 			}
 		},
 		"yargs-parser": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"version": "13.1.2",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs-parser/-/yargs-parser-13.1.2.tgz",
+			"integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"

--- a/packages/oas-resolver/package.json
+++ b/packages/oas-resolver/package.json
@@ -23,7 +23,7 @@
     "oas-kit-common": "^1.0.8",
     "reftools": "^1.1.0",
     "yaml": "^1.8.3",
-    "yargs": "^12.0.5"
+    "yargs": "^13.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
So, there's this security issue which doesn't show up in `npm audit` but does show up in our SourceClear scans as this CLI tool happens to be a part of our prod runtime transitively through use of `oas-validator`. This creates alerts, noise and general headache for us even if the code itself is not being run, so that's why I'm bumping it.