### PR TITLE
Upgrade yargs to latest version to fix vulnerabilities

### DIFF
--- a/packages/oas-resolver/package-lock.json
+++ b/packages/oas-resolver/package-lock.json
@@ -12,155 +12,94 @@
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
 		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+		},
+		"ansi-styles": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+			"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+			"requires": {
+				"@types/color-name": "^1.1.1",
+				"color-convert": "^2.0.1"
+			}
 		},
 		"camelcase": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"cliui": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
 			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
 			}
 		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-		},
-		"cross-spawn": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"color-name": "~1.1.4"
 			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
-		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"requires": {
-				"once": "^1.4.0"
-			}
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
-		"execa": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-			"requires": {
-				"cross-spawn": "^6.0.0",
-				"get-stream": "^4.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			}
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
 		},
 		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"requires": {
-				"locate-path": "^3.0.0"
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
 			}
 		},
 		"get-caller-file": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-		},
-		"get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"requires": {
-				"pump": "^3.0.0"
-			}
-		},
-		"invert-kv": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
 		"is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-		},
-		"lcid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-			"requires": {
-				"invert-kv": "^2.0.0"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 		},
 		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "^4.1.0"
 			}
-		},
-		"map-age-cleaner": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"requires": {
-				"p-defer": "^1.0.0"
-			}
-		},
-		"mem": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-			"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
-			"requires": {
-				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^1.0.0",
-				"p-is-promise": "^2.0.0"
-			}
-		},
-		"mimic-fn": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-		},
-		"nice-try": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"node-fetch-h2": {
 			"version": "2.3.0",
@@ -177,91 +116,44 @@
 				}
 			}
 		},
-		"npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+		"oas-kit-common": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+			"integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
 			"requires": {
-				"path-key": "^2.0.0"
+				"fast-safe-stringify": "^2.0.7"
 			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"os-locale": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-			"requires": {
-				"execa": "^1.0.0",
-				"lcid": "^2.0.0",
-				"mem": "^4.0.0"
-			}
-		},
-		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-		},
-		"p-is-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
 		},
 		"p-limit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
 			"requires": {
 				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^2.2.0"
 			}
 		},
 		"p-try": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 		},
-		"path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-		},
-		"pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
+		"reftools": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.0.tgz",
+			"integrity": "sha512-j3tFfOg3Zf0w/TT5bA6G/URUqAmsDhDJkBQ1cQX94Tfg/I4XO3j0p4Zf+2KQU90Ks6LHrQen5+gbe4POQu+jdQ=="
 		},
 		"regenerator-runtime": {
 			"version": "0.13.5",
@@ -274,66 +166,31 @@
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-		},
-		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
-		"shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"requires": {
-				"shebang-regex": "^1.0.0"
-			}
-		},
-		"shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-		},
-		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
 			}
 		},
 		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 			"requires": {
-				"ansi-regex": "^3.0.0"
-			}
-		},
-		"strip-eof": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-		},
-		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"requires": {
-				"isexe": "^2.0.0"
+				"ansi-regex": "^5.0.0"
 			}
 		},
 		"which-module": {
@@ -342,51 +199,14 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wrap-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
 			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"y18n": {
 			"version": "4.0.0",
@@ -402,28 +222,27 @@
 			}
 		},
 		"yargs": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
 			"requires": {
-				"cliui": "^4.0.0",
+				"cliui": "^6.0.0",
 				"decamelize": "^1.2.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^3.0.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
+				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
+				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^11.1.1"
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"version": "18.1.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+			"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"

--- a/packages/oas-resolver/package.json
+++ b/packages/oas-resolver/package.json
@@ -27,7 +27,7 @@
     "oas-kit-common": "^1.0.8",
     "reftools": "^1.1.0",
     "yaml": "^1.8.3",
-    "yargs": "^12.0.5"
+    "yargs": "^15.3.1"
   },
   "repository": {
     "type": "git",

--- a/packages/swagger2openapi/package-lock.json
+++ b/packages/swagger2openapi/package-lock.json
@@ -30,6 +30,22 @@
 				"regenerator-runtime": "^0.12.0"
 			}
 		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
+			}
+		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -63,9 +79,9 @@
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
 		},
 		"camelcase": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -86,6 +102,11 @@
 				"strip-ansi": "^4.0.0",
 				"wrap-ansi": "^2.0.0"
 			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"code-error-fragment": {
 			"version": "0.0.230",
@@ -132,10 +153,15 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -168,6 +194,21 @@
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
 			}
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
 		},
 		"find-up": {
 			"version": "3.0.0",
@@ -225,6 +266,11 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
 		"json-to-ast": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
@@ -270,19 +316,19 @@
 			}
 		},
 		"mem": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-			"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 			"requires": {
 				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^1.0.0",
+				"mimic-fn": "^2.0.0",
 				"p-is-promise": "^2.0.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -325,6 +371,104 @@
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
+		"oas-kit-common": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+			"integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+			"requires": {
+				"fast-safe-stringify": "^2.0.7"
+			}
+		},
+		"oas-linter": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.1.0.tgz",
+			"integrity": "sha512-Q2GD5QSmx1zFvW8RpDVIdRbR86mgpjTvO7b5XNnCSGkx96Hs7MdA/pWGctSZKNcxlbDy0c4eNSKC1dFbKGEjbg==",
+			"requires": {
+				"should": "^13.2.1",
+				"yaml": "^1.8.3"
+			}
+		},
+		"oas-resolver": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.3.1.tgz",
+			"integrity": "sha512-/zT9kjC0ip+fCu5CyUn366dHNldKHUHl8U1I/jZadzdYV+xC3goPy+3BamRboMNUuTTl6vyRajj9uL6mCkfyKw==",
+			"requires": {
+				"node-fetch-h2": "^2.3.0",
+				"oas-kit-common": "^1.0.8",
+				"reftools": "^1.1.0",
+				"yaml": "^1.8.3",
+				"yargs": "^12.0.5"
+			},
+			"dependencies": {
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				}
+			}
+		},
+		"oas-schema-walker": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.3.tgz",
+			"integrity": "sha512-spY1UVlewUhQs3v0ATsGySRCwVs4Uzutm9KvbwxkaitfisdJy9p51vLjaDGDV0g1xMcZIUH5f704/CwMPSZxHA=="
+		},
+		"oas-validator": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-4.0.1.tgz",
+			"integrity": "sha512-nlbhFqhP1fB02Gb92PCJEDN1TunPUWsTwlFONaHbsEKBSeNH3jH+CH/cA4W+y0xqAJHH/S55R5mIc6izD/GXQQ==",
+			"requires": {
+				"ajv": "^5.5.2",
+				"better-ajv-errors": "^0.6.7",
+				"call-me-maybe": "^1.0.1",
+				"oas-kit-common": "^1.0.8",
+				"oas-linter": "^3.1.0",
+				"oas-resolver": "^2.3.1",
+				"oas-schema-walker": "^1.1.3",
+				"reftools": "^1.1.0",
+				"should": "^13.2.1",
+				"yaml": "^1.8.3"
+			},
+			"dependencies": {
+				"better-ajv-errors": {
+					"version": "0.6.7",
+					"resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.6.7.tgz",
+					"integrity": "sha512-PYgt/sCzR4aGpyNy5+ViSQ77ognMnWq7745zM+/flYO4/Yisdtp9wDQW2IKCyVYPUxQt3E/b5GBSwfhd1LPdlg==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/runtime": "^7.0.0",
+						"chalk": "^2.4.1",
+						"core-js": "^3.2.1",
+						"json-to-ast": "^2.0.3",
+						"jsonpointer": "^4.0.1",
+						"leven": "^3.1.0"
+					}
+				},
+				"core-js": {
+					"version": "3.6.4",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+				},
+				"leven": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+					"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+				}
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -354,14 +498,14 @@
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
 		},
 		"p-limit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -375,9 +519,9 @@
 			}
 		},
 		"p-try": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -398,6 +542,11 @@
 				"once": "^1.3.1"
 			}
 		},
+		"reftools": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.0.tgz",
+			"integrity": "sha512-j3tFfOg3Zf0w/TT5bA6G/URUqAmsDhDJkBQ1cQX94Tfg/I4XO3j0p4Zf+2KQU90Ks6LHrQen5+gbe4POQu+jdQ=="
+		},
 		"regenerator-runtime": {
 			"version": "0.12.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
@@ -414,9 +563,9 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -436,10 +585,58 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
+		"should": {
+			"version": "13.2.3",
+			"resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+			"integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+			"requires": {
+				"should-equal": "^2.0.0",
+				"should-format": "^3.0.3",
+				"should-type": "^1.4.0",
+				"should-type-adaptors": "^1.0.1",
+				"should-util": "^1.0.0"
+			}
+		},
+		"should-equal": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+			"integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+			"requires": {
+				"should-type": "^1.4.0"
+			}
+		},
+		"should-format": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+			"requires": {
+				"should-type": "^1.3.0",
+				"should-type-adaptors": "^1.0.1"
+			}
+		},
+		"should-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+			"integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
+		},
+		"should-type-adaptors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+			"integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+			"requires": {
+				"should-type": "^1.3.0",
+				"should-util": "^1.0.0"
+			}
+		},
+		"should-util": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+			"integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="
+		},
 		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -560,22 +757,142 @@
 			}
 		},
 		"yargs": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
 			"requires": {
-				"cliui": "^4.0.0",
+				"cliui": "^6.0.0",
 				"decamelize": "^1.2.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^3.0.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
+				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
+				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^11.1.1"
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+					"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"yargs-parser": {

--- a/packages/swagger2openapi/package.json
+++ b/packages/swagger2openapi/package.json
@@ -44,7 +44,7 @@
     "oas-validator": "^4.0.1",
     "reftools": "^1.1.0",
     "yaml": "^1.8.3",
-    "yargs": "^12.0.5"
+    "yargs": "^15.3.1"
   },
   "keywords": [
     "swagger",


### PR DESCRIPTION
yargs@^12.0.5 has a vulnerability as reported by [snyk](https://snyk.io/):

```
✗ Prototype Pollution (new) [Medium Severity][https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381] 
in yargs-parser@11.1.1
introduced by yargs@12.0.5
```

This PR upgrades yargs to the latest version (15.3.1) in those repositories where it is being used:
- swagger2openapi
- oas-resolver