### PR TITLE
Mark request body required when OAS form param is required

### DIFF
--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -659,6 +659,7 @@ function processParameter(param, op, path, method, index, openapi, options) {
             if (param.required === true) {
                 if (!schema.required) schema.required = [];
                 schema.required.push(param.name);
+                result.required = true;
             }
             if (typeof param.default !== 'undefined') target.default = param.default;
             if (target.properties) target.properties = param.properties;

--- a/test/s2o-test/issue145/openapi.yaml
+++ b/test/s2o-test/issue145/openapi.yaml
@@ -22,6 +22,7 @@ paths:
                     type: string
               required:
                 - referenced_form_param
+        required: true
       responses:
         "201":
           description: Successful request.
@@ -45,6 +46,7 @@ paths:
                     type: string
               required:
                 - inline_form_param
+        required: true
       responses:
         "201":
           description: Successful request.

--- a/test/s2o-test/issue229/openapi.yaml
+++ b/test/s2o-test/issue229/openapi.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: swagger2openapi bug
+  description: Swagger doc that reproduces a bug in swagger2openapi
+paths:
+  "/cloud_directory/resend/{templateName}":
+    post:
+      security:
+        - Token: []
+      operationId: resendNotification
+      summary: Resend user notifications
+      description: Resend user email notifications
+      parameters:
+        - $ref: "#/components/parameters/templateName"
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                uuid:
+                  description: The Cloud Directory unique user Id.
+                  type: string
+              required:
+                - uuid
+        required: true
+      responses:
+        "202":
+          description: The notification will be send
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                example:
+                  message: Email is queued to be delivered.
+        "400":
+          description: The tenantId or request body is missing or invalid.
+          content:
+            application/json:
+              schema:
+                type: string
+components:
+  parameters:
+    templateName:
+      name: templateName
+      in: path
+      description: The type of email template.
+      required: true
+      schema:
+        type: string
+        enum:
+          - USER_VERIFICATION
+          - RESET_PASSWORD
+          - WELCOME
+          - PASSWORD_CHANGED
+  securitySchemes:
+    Token:
+      type: apiKey
+      name: Authorization
+      in: header
+      description: Security

--- a/test/s2o-test/issue229/swagger.yaml
+++ b/test/s2o-test/issue229/swagger.yaml
@@ -1,0 +1,57 @@
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: swagger2openapi bug
+  description: Swagger doc that reproduces a bug in swagger2openapi
+schemes:
+  - https
+securityDefinitions:
+  Token:
+    type: apiKey
+    name: Authorization
+    in: header
+    description: Security
+produces:
+  - application/json
+paths:
+  '/cloud_directory/resend/{templateName}':
+    post:
+      security:
+        - Token: []
+      operationId: resendNotification
+      summary: Resend user notifications
+      description: Resend user email notifications
+      consumes:
+        - application/x-www-form-urlencoded
+      parameters:
+        - $ref: '#/parameters/templateName'
+        - $ref: '#/parameters/cdUserId'
+      responses:
+        '202':
+          description: 'The notification will be send'
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+            example:
+              message: "Email is queued to be delivered."
+        '400':
+          description: The tenantId or request body is missing or invalid.
+          schema:
+            type: string
+
+parameters:
+  templateName:
+    name: templateName
+    in: path
+    description: The type of email template.
+    enum: ["USER_VERIFICATION", "RESET_PASSWORD", "WELCOME", "PASSWORD_CHANGED"]
+    required: true
+    type: string
+  cdUserId:
+    name: uuid
+    in: formData
+    description: The Cloud Directory unique user Id.
+    required: true
+    type: string


### PR DESCRIPTION
This PR adds logic to mark the request body of an operation as required if a formData parameter for that operation in the OAS2 file is required.

Fixes #229.