### PR TITLE
Upgrade ajv dependency version to ^6.12.3

### DIFF
--- a/packages/oas-validator/index.js
+++ b/packages/oas-validator/index.js
@@ -13,18 +13,16 @@ let ajv = require('ajv')({
     allErrors: true,
     verbose: true,
     jsonPointers: true,
-    patternGroups: true,
-    extendRefs: true // optional, current default is to 'fail', spec behaviour is to 'ignore'
+    meta: false, // optional, to prevent adding draft-06 meta-schema
+    extendRefs: true, // optional, current default is to 'fail', spec behaviour is to 'ignore'
+    schemaId: 'id' // optional, current default is to 'fail', spec behaviour is to 'ignore'
 });
-//meta: false, // optional, to prevent adding draft-06 meta-schema
 
 let ajvFormats = require('ajv/lib/compile/formats.js');
 ajv.addFormat('uriref', ajvFormats.full['uri-reference']);
-ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
-ajv._refs['http://json-schema.org/schema'] = 'http://json-schema.org/draft-04/schema'; // optional, using unversioned URI is out of spec
-let metaSchema = require('ajv/lib/refs/json-schema-v5.json');
+
+let metaSchema = require('ajv/lib/refs/json-schema-draft-04.json');
 ajv.addMetaSchema(metaSchema);
-ajv._opts.defaultMeta = metaSchema.id;
 
 const bae = require('better-ajv-errors');
 

--- a/packages/oas-validator/package.json
+++ b/packages/oas-validator/package.json
@@ -17,7 +17,7 @@
   "author": "Mike Ralphson",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "ajv": "^5.5.2",
+    "ajv": "^6.12.3",
     "better-ajv-errors": "^0.6.7",
     "call-me-maybe": "^1.0.1",
     "oas-kit-common": "^1.0.8",


### PR DESCRIPTION
Fixing the following vulnerability: https://snyk.io/test/npm/swagger2openapi.
Tests passing with `lts/dubnium` (`node v10.22.0`)