### PR TITLE
Fix misplaced description property if refSiblings = allOf

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -240,7 +240,7 @@
         "sort-imports": "error",
         "sort-keys": "off",
         "sort-vars": "error",
-        "space-before-blocks": "off",
+        "space-before-blocks": "error",
         "space-before-function-paren": "off",
         "space-in-parens": [
             "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -240,7 +240,7 @@
         "sort-imports": "error",
         "sort-keys": "off",
         "sort-vars": "error",
-        "space-before-blocks": "error",
+        "space-before-blocks": "off",
         "space-before-function-paren": "off",
         "space-in-parens": [
             "error",

--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -307,9 +307,9 @@ function fixupRefs(obj, key, state) {
             }
             else if (inSchema && (options.refSiblings === 'allOf')) {
                 delete obj.$ref;
-                if(typeof obj.description === 'string') {
+                if (typeof obj.description === 'string') {
                     state.parent[state.pkey] = { allOf: [ { $ref: tmpRef } ], description: obj.description };
-                }else{
+                } else {
                     state.parent[state.pkey] = { allOf: [ { $ref: tmpRef }, obj ]};
                 }
             }

--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -183,7 +183,7 @@ function fixUpSubSchemaExtensions(schema,parent) {
 }
 
 function fixUpSchema(schema,options) {
-    sw.walkSchema(schema,{},{},function(schema,parent,state){
+    sw.walkSchema(schema,{},{},function(schema,parent,state) {
         fixUpSubSchemaExtensions(schema,parent);
         fixUpSubSchema(schema,parent,options);
     });
@@ -307,7 +307,7 @@ function fixupRefs(obj, key, state) {
             }
             else if (inSchema && (options.refSiblings === 'allOf')) {
                 delete obj.$ref;
-                if(typeof obj.description === 'string'){
+                if(typeof obj.description === 'string') {
                     state.parent[state.pkey] = { allOf: [ { $ref: tmpRef } ], description: obj.description };
                 }else{
                     state.parent[state.pkey] = { allOf: [ { $ref: tmpRef }, obj ]};
@@ -1404,7 +1404,7 @@ function convertObj(swagger, options, callback) {
             fixPaths(options.openapi, options, reject);
 
             resolver.optionalResolve(options) // is a no-op if options.resolve is not set
-            .then(function(){
+            .then(function() {
                 if (options.direct) {
                     return resolve(options.openapi);
                 }
@@ -1412,7 +1412,7 @@ function convertObj(swagger, options, callback) {
                     return resolve(options);
                 }
             })
-            .catch(function(ex){
+            .catch(function(ex) {
                 console.warn(ex);
                 reject(ex);
             });
@@ -1443,7 +1443,7 @@ function convertObj(swagger, options, callback) {
         // we want the new and existing properties to appear in a sensible order. Not guaranteed
         openapi = Object.assign(openapi, cclone(swagger));
         delete openapi.swagger;
-        recurse(openapi, {}, function(obj, key, state){
+        recurse(openapi, {}, function(obj, key, state) {
             if ((obj[key] === null) && (!key.startsWith('x-')) && key !== 'default' && (state.path.indexOf('/example') < 0)) delete obj[key]; // this saves *so* much grief later
         });
 
@@ -1550,7 +1550,7 @@ function convertObj(swagger, options, callback) {
         delete openapi.securityDefinitions;
 
         resolver.optionalResolve(options) // is a no-op if options.resolve is not set
-        .then(function(){
+        .then(function() {
             main(options.openapi, options);
             if (options.direct) {
                 resolve(options.openapi);
@@ -1559,7 +1559,7 @@ function convertObj(swagger, options, callback) {
                 resolve(options);
             }
         })
-        .catch(function(ex){
+        .catch(function(ex) {
             console.warn(ex);
             reject(ex);
         });

--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -307,7 +307,11 @@ function fixupRefs(obj, key, state) {
             }
             else if (inSchema && (options.refSiblings === 'allOf')) {
                 delete obj.$ref;
-                state.parent[state.pkey] = { allOf: [ { $ref: tmpRef }, obj ]};
+                if(typeof obj.description === 'string'){
+                    state.parent[state.pkey] = { allOf: [ { $ref: tmpRef } ], description: obj.description };
+                }else{
+                    state.parent[state.pkey] = { allOf: [ { $ref: tmpRef }, obj ]};
+                }
             }
             else { // remove, or not 'preserve' and not in a schema
                 state.parent[state.pkey] = { $ref: tmpRef };

--- a/test/s2o-test/issue130-allOf/openapi.yaml
+++ b/test/s2o-test/issue130-allOf/openapi.yaml
@@ -15,9 +15,15 @@ components:
     a:
       allOf:
       - $ref: '#/components/schemas/b'
-      - description: a
+      description: a
     b:
       type: integer
+    c:
+      allOf:
+      - $ref: '#/components/schemas/b'
+      - properties:
+          name:
+            type: 'string'
   parameters:
     c:
       name: c

--- a/test/s2o-test/issue130-allOf/swagger.yaml
+++ b/test/s2o-test/issue130-allOf/swagger.yaml
@@ -22,3 +22,8 @@ definitions:
     description: a
   b:
     type: integer
+  c:
+    $ref: '#/definitions/b'
+    properties:
+      name:
+        type: 'string'


### PR DESCRIPTION
I think there is a bug with refSiblings = allOf and description next to $ref property in a swagger input schema.

```yml
# swagger input
  a:
    $ref: '#/definitions/b'
    description: a
# wrong output
   a:
      allOf:
      - $ref: '#/components/schemas/b'
        description: a
# fixed output
   a:
      allOf:
      - $ref: '#/components/schemas/b'
      description: a
```

A description property next to a $ref property should be moved next to new allOf (and not into allOf array). Only e.g. an existing properties object (or any other sub schema) next to a $ref property should be moved into allOf array (see also https://json-schema.org/understanding-json-schema/structuring.html#id5).

See also #130