### PR TITLE
Fix require fetch package name

### DIFF
--- a/packages/swagger2openapi/boast.js
+++ b/packages/swagger2openapi/boast.js
@@ -7,7 +7,7 @@
 const fs = require('fs');
 
 const yaml = require('yaml');
-const fetch = require('node-fetch');
+const fetch = require('node-fetch-h2');
 
 const swagger2openapi = require('./index.js');
 const validator = require('oas-validator');


### PR DESCRIPTION
# What happens?

Attempting to run the swagger2api command with the npx command results in an error message.

```
Cannot find module 'node-fetch'
```

# How to reproduce? (before fix)

```
# (example) move to HOME dir
cd ~/

# execute by npx command
~ took 5s 
> npx swagger2openapi
npx: installed 47 in 3.447s
Cannot find module 'node-fetch'
Require stack:
- /Users/kaishuu0123/.npm/_npx/12640/lib/node_modules/swagger2openapi/boast.js
```

# Notes

Is this the correct fix?
Do you want to use node-fetch?