### PR TITLE
fix: ensure that refs gets updated after resolving shared refs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -54,7 +54,7 @@ refSiblings|string|Input|Controls handling of `$ref` which has sibling propertie
 resolve|Boolean|Input|Flag to enable resolution of external `$ref`s
 resolveInternal|Boolean|Input|Flag to enable resolution of internal `$ref`s. Also disables deduplication of `requestBodies`
 resolver|Object|Internal|Used by the resolver to track outstanding resolutions
-resolveSharedRefs|Boolean|Used by the resolver to factor out the same schemas, referenced in more than 1 place into the `#/components/schemas/` section.
+resolveSharedRefs|Boolean|Input|Used by the resolver to factor out the same schemas, referenced in more than 1 place into the `#/components/schemas/` section.
 skip|Boolean|Reserved|Used by tools such as Speccy to skip linter rules
 stop|Boolean|Input|Command-line flag used by `testRunner`
 source|String|Input|The source filename or url of the definition, used by the resolver

--- a/docs/options.md
+++ b/docs/options.md
@@ -54,6 +54,7 @@ refSiblings|string|Input|Controls handling of `$ref` which has sibling propertie
 resolve|Boolean|Input|Flag to enable resolution of external `$ref`s
 resolveInternal|Boolean|Input|Flag to enable resolution of internal `$ref`s. Also disables deduplication of `requestBodies`
 resolver|Object|Internal|Used by the resolver to track outstanding resolutions
+resolveSharedRefs|Boolean|Used by the resolver to factor out the same schemas, referenced in more than 1 place into the `#/components/schemas/` section.
 skip|Boolean|Reserved|Used by tools such as Speccy to skip linter rules
 stop|Boolean|Input|Command-line flag used by `testRunner`
 source|String|Input|The source filename or url of the definition, used by the resolver

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lerna": "^3.20.2",
     "mocha": "^8.0.1",
     "should": "^13.2.1",
+    "sinon": "^9.2.2",
     "webpack": "^5.6.0",
     "webpack-bundle-analyzer": "^4.1.0",
     "webpack-cli": "^4.2.0",

--- a/test/resolver.test.js
+++ b/test/resolver.test.js
@@ -4,11 +4,23 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 const yaml = require('yaml');
+const sinon = require('sinon');
+const crypto = require('crypto');
 
 const resolver = require('../packages/oas-resolver');
 
 const tests = fs.readdirSync(path.join(__dirname,'resolver')).filter(file => {
     return fs.statSync(path.join(__dirname, 'resolver', file)).isDirectory() && file !== 'include';
+});
+
+sinon.stub(crypto, 'createHash').callsFake(() => {
+    return {
+        update: sinon.stub().callsFake(() => {
+            return {
+                digest: sinon.stub().returns('123')
+            };
+        })
+    };
 });
 
 describe('Resolver tests', () => {

--- a/test/resolver/resolveSharedRefs-case-1/input.yaml
+++ b/test/resolver/resolveSharedRefs-case-1/input.yaml
@@ -1,0 +1,87 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas: {}
+  responses:
+    Post201:
+      $ref: 'responses.yaml#/components/responses/Post201'
+    Post202:
+      $ref: 'responses.yaml#/components/responses/Post202'
+    Post203:
+      $ref: 'responses.yaml#/components/responses/Post203'
+    Post204:
+      $ref: 'responses.yaml#/components/responses/Post204'
+    Post205:
+      $ref: 'responses.yaml#/components/responses/Post205'
+    Post206:
+      $ref: 'responses.yaml#/components/responses/Post206'
+    Post207:
+      $ref: 'responses.yaml#/components/responses/Post207'
+    Post208:
+      $ref: 'responses.yaml#/components/responses/Post208'
+    TestModel:
+      description: A test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-model.json'
+    TestPublicModel:
+      description: A public test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-public-model.json'
+

--- a/test/resolver/resolveSharedRefs-case-1/models/paging.json
+++ b/test/resolver/resolveSharedRefs-case-1/models/paging.json
@@ -1,0 +1,23 @@
+{
+    "title": "Paging",
+    "required": ["_links"],
+    "type": "object",
+    "properties": {
+      "nextToken": {
+        "type": "string",
+        "description": "The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch"
+      },
+      "currentToken": {
+        "type": "string",
+        "description": "The pagination token for the current page"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "The number of records to return on the page not to exceed 200"
+      },
+      "totalCount": {
+        "type": "integer",
+        "description": "The total number of records available"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-1/models/test-model.json
+++ b/test/resolver/resolveSharedRefs-case-1/models/test-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample model.",
+    "required": ["id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "id": {
+        "type": "string",
+        "example": "abc-123"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-1/models/test-public-model.json
+++ b/test/resolver/resolveSharedRefs-case-1/models/test-public-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample public model.",
+    "required": ["public-id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "public-id": {
+        "type": "string",
+        "example": "some type"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-1/options.yaml
+++ b/test/resolver/resolveSharedRefs-case-1/options.yaml
@@ -1,0 +1,2 @@
+#preserveMiro: false
+resolveSharedRefs: true

--- a/test/resolver/resolveSharedRefs-case-1/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-1/output.yaml
@@ -71,7 +71,7 @@ components:
         id:
           description: the local identifier (not necessarily globally unique)
           type: string
-    xyz-123:
+    xyz-0:
       title: XYZ
       description: this is xyz
       type: object
@@ -79,7 +79,7 @@ components:
         id:
           description: the local identifier (not necessarily globally unique)
           type: string
-    abc-123:
+    abc-0:
       title: abc
       description: this is abc
       type: object
@@ -123,13 +123,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/xyz-123'
+            $ref: '#/components/schemas/xyz-0'
     Post204:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/xyz-123'
+            $ref: '#/components/schemas/xyz-0'
     Post205:
       description: Success post
       content:
@@ -147,13 +147,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc-123'
+            $ref: '#/components/schemas/abc-0'
     Post208:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc-123'
+            $ref: '#/components/schemas/abc-0'
     TestModel:
         description: A test model
         content:

--- a/test/resolver/resolveSharedRefs-case-1/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-1/output.yaml
@@ -1,0 +1,188 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas:
+    xyz:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    xyz-123:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc-123:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    paging:
+      title: Paging
+      required:
+        - _links
+      type: object
+      properties:
+        nextToken:
+          type: string
+          description: The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch
+        currentToken:
+          type: string
+          description: The pagination token for the current page
+        limit:
+          type: integer
+          description: The number of records to return on the page not to exceed 200
+        totalCount:
+          type: integer
+          description: The total number of records available
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/xyz'
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/xyz'
+    Post203:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/xyz-123'
+    Post204:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/xyz-123'
+    Post205:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/abc'
+    Post206:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/abc'
+    Post207:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/abc-123'
+    Post208:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/abc-123'
+    TestModel:
+        description: A test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample model.
+              required:
+                - id
+              type: object
+              properties:
+                id:
+                  type: string
+                  example: abc-123
+                paging:
+                  $ref: '#/components/schemas/paging'
+    TestPublicModel:
+        description: A public test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample public model.
+              required:
+                - public-id
+              type: object
+              properties:
+                public-id:
+                  type: string
+                  example: some type
+                paging:
+                  $ref: '#/components/schemas/paging'

--- a/test/resolver/resolveSharedRefs-case-1/responses.yaml
+++ b/test/resolver/resolveSharedRefs-case-1/responses.yaml
@@ -1,0 +1,56 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Response schemas
+  description: Response definitions commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/xyz'
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/xyz'
+    Post203:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas2.yaml#/components/schemas/xyz'
+    Post204:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas2.yaml#/components/schemas/xyz'
+    Post205:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/abc'
+    Post206:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/abc'
+    Post207:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas2.yaml#/components/schemas/abc'
+    Post208:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas2.yaml#/components/schemas/abc'

--- a/test/resolver/resolveSharedRefs-case-1/schemas.yaml
+++ b/test/resolver/resolveSharedRefs-case-1/schemas.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Message/JSON schemas
+  description: Message schemas / JSON datatypes commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  schemas:
+    xyz:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string

--- a/test/resolver/resolveSharedRefs-case-1/schemas2.yaml
+++ b/test/resolver/resolveSharedRefs-case-1/schemas2.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Message/JSON schemas
+  description: Message schemas / JSON datatypes commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  schemas:
+    xyz:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string

--- a/test/resolver/resolveSharedRefs-case-2/input.yaml
+++ b/test/resolver/resolveSharedRefs-case-2/input.yaml
@@ -1,0 +1,79 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas: {}
+  responses:
+    Post201:
+      $ref: 'responses.yaml#/components/responses/Post201'
+    Post202:
+      $ref: 'responses.yaml#/components/responses/Post202'
+    Post203:
+      $ref: 'responses.yaml#/components/responses/Post203'
+    Post204:
+      $ref: 'responses.yaml#/components/responses/Post204'
+    TestModel:
+      description: A test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-model.json'
+    TestPublicModel:
+      description: A public test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-public-model.json'
+

--- a/test/resolver/resolveSharedRefs-case-2/models/paging.json
+++ b/test/resolver/resolveSharedRefs-case-2/models/paging.json
@@ -1,0 +1,23 @@
+{
+    "title": "Paging",
+    "required": ["_links"],
+    "type": "object",
+    "properties": {
+      "nextToken": {
+        "type": "string",
+        "description": "The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch"
+      },
+      "currentToken": {
+        "type": "string",
+        "description": "The pagination token for the current page"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "The number of records to return on the page not to exceed 200"
+      },
+      "totalCount": {
+        "type": "integer",
+        "description": "The total number of records available"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-2/models/test-model.json
+++ b/test/resolver/resolveSharedRefs-case-2/models/test-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample model.",
+    "required": ["id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "id": {
+        "type": "string",
+        "example": "abc-123"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-2/models/test-public-model.json
+++ b/test/resolver/resolveSharedRefs-case-2/models/test-public-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample public model.",
+    "required": ["public-id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "public-id": {
+        "type": "string",
+        "example": "some type"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-2/options.yaml
+++ b/test/resolver/resolveSharedRefs-case-2/options.yaml
@@ -1,0 +1,2 @@
+#preserveMiro: false
+resolveSharedRefs: true

--- a/test/resolver/resolveSharedRefs-case-2/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-2/output.yaml
@@ -1,0 +1,148 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas:
+    xyz:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    paging:
+      title: Paging
+      required:
+        - _links
+      type: object
+      properties:
+        nextToken:
+          type: string
+          description: The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch
+        currentToken:
+          type: string
+          description: The pagination token for the current page
+        limit:
+          type: integer
+          description: The number of records to return on the page not to exceed 200
+        totalCount:
+          type: integer
+          description: The total number of records available
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/xyz'
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/xyz'
+    Post203:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/abc'
+    Post204:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/abc'
+    TestModel:
+        description: A test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample model.
+              required:
+                - id
+              type: object
+              properties:
+                id:
+                  type: string
+                  example: abc-123
+                paging:
+                  $ref: '#/components/schemas/paging'
+    TestPublicModel:
+        description: A public test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample public model.
+              required:
+                - public-id
+              type: object
+              properties:
+                public-id:
+                  type: string
+                  example: some type
+                paging:
+                  $ref: '#/components/schemas/paging'

--- a/test/resolver/resolveSharedRefs-case-2/responses.yaml
+++ b/test/resolver/resolveSharedRefs-case-2/responses.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Response schemas
+  description: Response definitions commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/xyz'
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/xyz'
+    Post203:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/abc'
+    Post204:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/abc'

--- a/test/resolver/resolveSharedRefs-case-2/schemas.yaml
+++ b/test/resolver/resolveSharedRefs-case-2/schemas.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Message/JSON schemas
+  description: Message schemas / JSON datatypes commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  schemas:
+    xyz:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string

--- a/test/resolver/resolveSharedRefs-case-3/input.yaml
+++ b/test/resolver/resolveSharedRefs-case-3/input.yaml
@@ -1,0 +1,75 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas: {}
+  responses:
+    Post201:
+      $ref: 'responses.yaml#/components/responses/Post201'
+    Post202:
+      $ref: 'responses.yaml#/components/responses/Post202'
+    TestModel:
+      description: A test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-model.json'
+    TestPublicModel:
+      description: A public test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-public-model.json'
+

--- a/test/resolver/resolveSharedRefs-case-3/models/paging.json
+++ b/test/resolver/resolveSharedRefs-case-3/models/paging.json
@@ -1,0 +1,23 @@
+{
+    "title": "Paging",
+    "required": ["_links"],
+    "type": "object",
+    "properties": {
+      "nextToken": {
+        "type": "string",
+        "description": "The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch"
+      },
+      "currentToken": {
+        "type": "string",
+        "description": "The pagination token for the current page"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "The number of records to return on the page not to exceed 200"
+      },
+      "totalCount": {
+        "type": "integer",
+        "description": "The total number of records available"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-3/models/test-model.json
+++ b/test/resolver/resolveSharedRefs-case-3/models/test-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample model.",
+    "required": ["id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "id": {
+        "type": "string",
+        "example": "abc-123"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-3/models/test-public-model.json
+++ b/test/resolver/resolveSharedRefs-case-3/models/test-public-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample public model.",
+    "required": ["public-id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "public-id": {
+        "type": "string",
+        "example": "some type"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-3/options.yaml
+++ b/test/resolver/resolveSharedRefs-case-3/options.yaml
@@ -1,0 +1,2 @@
+#preserveMiro: false
+resolveSharedRefs: true

--- a/test/resolver/resolveSharedRefs-case-3/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-3/output.yaml
@@ -1,0 +1,132 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas:
+    paging:
+      title: Paging
+      required:
+        - _links
+      type: object
+      properties:
+        nextToken:
+          type: string
+          description: The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch
+        currentToken:
+          type: string
+          description: The pagination token for the current page
+        limit:
+          type: integer
+          description: The number of records to return on the page not to exceed 200
+        totalCount:
+          type: integer
+          description: The total number of records available
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            title: XYZ
+            description: this is xyz
+            type: object
+            properties:
+              id:
+                description: the local identifier (not necessarily globally unique)
+                type: string
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            title: abc
+            description: this is abc
+            type: object
+            properties:
+              id:
+                description: the local identifier (not necessarily globally unique)
+                type: string
+    TestModel:
+        description: A test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample model.
+              required:
+                - id
+              type: object
+              properties:
+                id:
+                  type: string
+                  example: abc-123
+                paging:
+                  $ref: '#/components/schemas/paging'
+    TestPublicModel:
+        description: A public test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample public model.
+              required:
+                - public-id
+              type: object
+              properties:
+                public-id:
+                  type: string
+                  example: some type
+                paging:
+                  $ref: '#/components/schemas/paging'

--- a/test/resolver/resolveSharedRefs-case-3/responses.yaml
+++ b/test/resolver/resolveSharedRefs-case-3/responses.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Response schemas
+  description: Response definitions commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/xyz'
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/abc'

--- a/test/resolver/resolveSharedRefs-case-3/schemas.yaml
+++ b/test/resolver/resolveSharedRefs-case-3/schemas.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Message/JSON schemas
+  description: Message schemas / JSON datatypes commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  schemas:
+    xyz:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string

--- a/test/resolver/resolveSharedRefs-case-4/input.yaml
+++ b/test/resolver/resolveSharedRefs-case-4/input.yaml
@@ -1,0 +1,75 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas: {}
+  responses:
+    Post201:
+      $ref: 'responses.yaml#/components/responses/Post201'
+    Post202:
+      $ref: 'responses.yaml#/components/responses/Post202'
+    TestModel:
+      description: A test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-model.json'
+    TestPublicModel:
+      description: A public test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-public-model.json'
+

--- a/test/resolver/resolveSharedRefs-case-4/models/paging.json
+++ b/test/resolver/resolveSharedRefs-case-4/models/paging.json
@@ -1,0 +1,23 @@
+{
+    "title": "Paging",
+    "required": ["_links"],
+    "type": "object",
+    "properties": {
+      "nextToken": {
+        "type": "string",
+        "description": "The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch"
+      },
+      "currentToken": {
+        "type": "string",
+        "description": "The pagination token for the current page"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "The number of records to return on the page not to exceed 200"
+      },
+      "totalCount": {
+        "type": "integer",
+        "description": "The total number of records available"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-4/models/test-model.json
+++ b/test/resolver/resolveSharedRefs-case-4/models/test-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample model.",
+    "required": ["id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "id": {
+        "type": "string",
+        "example": "abc-123"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-4/models/test-public-model.json
+++ b/test/resolver/resolveSharedRefs-case-4/models/test-public-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample public model.",
+    "required": ["public-id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "public-id": {
+        "type": "string",
+        "example": "some type"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-4/options.yaml
+++ b/test/resolver/resolveSharedRefs-case-4/options.yaml
@@ -1,0 +1,2 @@
+#preserveMiro: false
+resolveSharedRefs: true

--- a/test/resolver/resolveSharedRefs-case-4/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-4/output.yaml
@@ -1,0 +1,142 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas:
+    paging:
+      title: Paging
+      required:
+        - _links
+      type: object
+      properties:
+        nextToken:
+          type: string
+          description: The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch
+        currentToken:
+          type: string
+          description: The pagination token for the current page
+        limit:
+          type: integer
+          description: The number of records to return on the page not to exceed 200
+        totalCount:
+          type: integer
+          description: The total number of records available
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            title: XYZ
+            description: this is xyz
+            type: object
+            properties:
+              id:
+                description: the local identifier (not necessarily globally unique)
+                type: string
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            title: abc
+            description: this is abc
+            type: object
+            properties:
+              id:
+                description: the local identifier (not necessarily globally unique)
+                type: string
+              details:
+                title: abc
+                description: this is abc
+                type: object
+                properties:
+                  id:
+                    description: the local identifier (not necessarily globally unique)
+                    type: string
+                  details:
+                    $ref: '#/components/responses/Post202/content/application~1json/schema/properties/details'
+    TestModel:
+        description: A test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample model.
+              required:
+                - id
+              type: object
+              properties:
+                id:
+                  type: string
+                  example: abc-123
+                paging:
+                  $ref: '#/components/schemas/paging'
+    TestPublicModel:
+        description: A public test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample public model.
+              required:
+                - public-id
+              type: object
+              properties:
+                public-id:
+                  type: string
+                  example: some type
+                paging:
+                  $ref: '#/components/schemas/paging'

--- a/test/resolver/resolveSharedRefs-case-4/responses.yaml
+++ b/test/resolver/resolveSharedRefs-case-4/responses.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Response schemas
+  description: Response definitions commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/xyz'
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/abc'

--- a/test/resolver/resolveSharedRefs-case-4/schemas.yaml
+++ b/test/resolver/resolveSharedRefs-case-4/schemas.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Message/JSON schemas
+  description: Message schemas / JSON datatypes commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  schemas:
+    xyz:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+        details:
+          description: a list of details
+          type: array
+          $ref: '#/components/schemas/abc'

--- a/test/resolver/resolveSharedRefs-case-5/input.yaml
+++ b/test/resolver/resolveSharedRefs-case-5/input.yaml
@@ -1,0 +1,77 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas: {}
+  responses:
+    Post201:
+      $ref: 'responses.yaml#/components/responses/Post201'
+    Post202:
+      $ref: 'responses.yaml#/components/responses/Post202'
+    Post203:
+      $ref: 'responses.yaml#/components/responses/Post203'
+    TestModel:
+      description: A test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-model.json'
+    TestPublicModel:
+      description: A public test model
+      content:
+        application/json:
+          schema:
+            $ref: './models/test-public-model.json'
+

--- a/test/resolver/resolveSharedRefs-case-5/models/paging.json
+++ b/test/resolver/resolveSharedRefs-case-5/models/paging.json
@@ -1,0 +1,23 @@
+{
+    "title": "Paging",
+    "required": ["_links"],
+    "type": "object",
+    "properties": {
+      "nextToken": {
+        "type": "string",
+        "description": "The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch"
+      },
+      "currentToken": {
+        "type": "string",
+        "description": "The pagination token for the current page"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "The number of records to return on the page not to exceed 200"
+      },
+      "totalCount": {
+        "type": "integer",
+        "description": "The total number of records available"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-5/models/test-model.json
+++ b/test/resolver/resolveSharedRefs-case-5/models/test-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample model.",
+    "required": ["id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "id": {
+        "type": "string",
+        "example": "abc-123"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-5/models/test-public-model.json
+++ b/test/resolver/resolveSharedRefs-case-5/models/test-public-model.json
@@ -1,0 +1,15 @@
+{
+    "title": "Id only entity",
+    "description": "A sample public model.",
+    "required": ["public-id"],
+    "type": "object",
+    "properties": {
+      "paging": {
+        "$ref": "paging.json"
+      },
+      "public-id": {
+        "type": "string",
+        "example": "some type"
+      }
+    }
+  }

--- a/test/resolver/resolveSharedRefs-case-5/options.yaml
+++ b/test/resolver/resolveSharedRefs-case-5/options.yaml
@@ -1,0 +1,2 @@
+#preserveMiro: false
+resolveSharedRefs: true

--- a/test/resolver/resolveSharedRefs-case-5/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-5/output.yaml
@@ -1,0 +1,144 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: API
+  description: A service for testing the resolve script
+tags:
+  - name: test
+    description: a test tag
+  - name: TestTag
+    description: another test tag
+paths:
+  /foo:
+    post:
+      operationId: postFoo
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /bar:
+    post:
+      operationId: postBar
+      summary: Super post op
+      tags:
+        - test
+      responses:
+        '201':
+          $ref: '#/components/responses/Post201'
+  /test:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestModel'
+      deprecated: false
+  /test-public:
+    get:
+      tags:
+        - TestTag
+      security:
+        - bearer: []
+      summary: An endpoint for testing
+      description: A test description
+      operationId: testEndpoint
+      responses:
+        200:
+          $ref: '#/components/responses/TestPublicModel'
+      deprecated: false
+components:
+  schemas:
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+        details:
+          $ref: '#/components/schemas/abc'
+          description: a list of details
+          type: array
+    paging:
+      title: Paging
+      required:
+        - _links
+      type: object
+      properties:
+        nextToken:
+          type: string
+          description: The pagination token for the next page; if available. You can use this to determine if there is additional data to fetch
+        currentToken:
+          type: string
+          description: The pagination token for the current page
+        limit:
+          type: integer
+          description: The number of records to return on the page not to exceed 200
+        totalCount:
+          type: integer
+          description: The total number of records available
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            title: XYZ
+            description: this is xyz
+            type: object
+            properties:
+              id:
+                description: the local identifier (not necessarily globally unique)
+                type: string
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/abc'
+    Post203:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/abc'
+    TestModel:
+        description: A test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample model.
+              required:
+                - id
+              type: object
+              properties:
+                id:
+                  type: string
+                  example: abc-123
+                paging:
+                  $ref: '#/components/schemas/paging'
+    TestPublicModel:
+        description: A public test model
+        content:
+          application/json:
+            schema:
+              title: Id only entity
+              description: A sample public model.
+              required:
+                - public-id
+              type: object
+              properties:
+                public-id:
+                  type: string
+                  example: some type
+                paging:
+                  $ref: '#/components/schemas/paging'

--- a/test/resolver/resolveSharedRefs-case-5/responses.yaml
+++ b/test/resolver/resolveSharedRefs-case-5/responses.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Response schemas
+  description: Response definitions commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  responses:
+    Post201:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/xyz'
+    Post202:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/abc'
+    Post203:
+      description: Success post
+      content:
+        application/json:
+          schema:
+            $ref: 'schemas.yaml#/components/schemas/abc'

--- a/test/resolver/resolveSharedRefs-case-5/schemas.yaml
+++ b/test/resolver/resolveSharedRefs-case-5/schemas.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Common Message/JSON schemas
+  description: Message schemas / JSON datatypes commonly used in API-docs in a separate reference file
+paths: {}
+components:
+  schemas:
+    xyz:
+      title: XYZ
+      description: this is xyz
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+    abc:
+      title: abc
+      description: this is abc
+      type: object
+      properties:
+        id:
+          description: the local identifier (not necessarily globally unique)
+          type: string
+        details:
+          description: a list of details
+          type: array
+          $ref: 'schemas.yaml#/components/schemas/abc'


### PR DESCRIPTION
we weren't updating the resolvedAt property for a ref; meaning that the logic that was checking if the ref already existed wasn't work.

additionally, removed the crypto logic as it was necessary and could be replaced by a simple counter.