### PR TITLE
Strip trailing slashes when generating OpenAPI server URLs from basePath

### DIFF
--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -1450,7 +1450,8 @@ function convertObj(swagger, options, callback) {
         if (swagger.host) {
             for (let s of (Array.isArray(swagger.schemes) ? swagger.schemes : [''])) {
                 let server = {};
-                server.url = (s ? s+':' : '') + '//' + swagger.host + (swagger.basePath ? swagger.basePath : '');
+                let basePath = (swagger.basePath || '').replace(/\/$/, '') // Trailing slashes generally shouldn't be included
+                server.url = (s ? s+':' : '') + '//' + swagger.host + basePath;
                 extractServerParameters(server);
                 if (!openapi.servers) openapi.servers = [];
                 openapi.servers.push(server);

--- a/test/s2o-test/pull348-trailing-slash/openapi.yaml
+++ b/test/s2o-test/pull348-trailing-slash/openapi.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: API
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/test/s2o-test/pull348-trailing-slash/swagger.yaml
+++ b/test/s2o-test/pull348-trailing-slash/swagger.yaml
@@ -1,0 +1,14 @@
+swagger: 2.0
+info:
+  title: API
+  version: 1.0.0
+basePath: /
+host: example.com
+schemes:
+  - https
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
These aren't strictly prohibited by the OpenAPI spec AFAIK, but I think they're almost certainly not intended, and Stoplight's linting [recommends](https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md#oas3-server-trailing-slash) against trailing slashes in general.

This most notably occurs with `basePath: /` in Swagger. This is pretty clearly intended to mean "paths are all relative to the server root", so we don't need a trailing slash in the resulting `servers` URLs. A good few swagger specs in the openapi directory do this.

Also `/` is the default value for `basePath`, so setting that explicitly should be equivalent to not setting the basePath at all. Currently it's not, and `''` is used as the default instead. This change makes them consistent.