### PR TITLE
fix: swagger formData error

### DIFF
--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -531,7 +531,7 @@ function processParameter(param, op, path, method, index, openapi, options) {
             delete param['x-example'];
         }
 
-        if ((param.in !== 'body') && (!param.type)) {
+        if ((!['body', 'formData'].includes(param.in)) && (!param.type)) {
             if (options.patch) {
                 options.patches++;
                 param.type = 'string';


### PR DESCRIPTION
/node_modules/swagger2openapi/index.js:39
    let err = new S2OError(message);
              ^

S2OError: (Patchable) parameter.type is mandatory for non-body parameters
    at throwError (/node_modules/swagger2openapi/index.js:39:15)
    at processParameter (/node_modules/swagger2openapi/index.js:541:17)
    at processPaths (/node_modules/swagger2openapi/index.js:952:30)
    at main (/node_modules/swagger2openapi/index.js:1187:5)
    /node_modules/swagger2openapi/index.js:1556:13

PARAMS={
  in: 'formData',
  name: 'file',
  description: 'upload file',
  required: false,
  schema: { type: 'file' }
}