### PR TITLE
Fixed issue where conversion to openapi 3 from swagger 2 definition was failing due to TypeError.

### DIFF
--- a/packages/swagger2openapi/index.js
+++ b/packages/swagger2openapi/index.js
@@ -171,7 +171,7 @@ function fixUpSubSchemaExtensions(schema,parent) {
         delete schema["x-discriminator"];
         for (let entry in schema.discriminator.mapping) {
             let schemaOrRef = schema.discriminator.mapping[entry];
-            if (schemaOrRef.startsWith('#/definitions/')) {
+            if (typeof schemaOrRef === 'string' && schemaOrRef.startsWith('#/definitions/')) {
                 schema.discriminator.mapping[entry] = schemaOrRef.replace('#/definitions/','#/components/schemas/');
             }
         }


### PR DESCRIPTION
## Overview

This PR fixes one of the issue causing TypeError while converting Swagger 2.0 definition to OpenAPI 3.0. Issue was happening due to expecting certain property of definition `schemaOrRef` as string always. This results in a TypeError if this property is non-string and it can be non-string as rather than mentioning `$ref` here, one can use schema directly.

```
TypeError: SWAGGER2.0: schemaOrRef.startsWith is not a function
  File "/var/www-api/node_modules/swagger2openapi/index.js", line 182, col 29, in fixUpSubSchemaExtensions
    if (schemaOrRef.startsWith('#/definitions/')) {
  File "/var/www-api/node_modules/swagger2openapi/index.js", line 191, col 9, in null.<anonymous>
    fixUpSubSchemaExtensions(schema,parent);
  File "/var/www-api/node_modules/oas-schema-walker/index.js", line 53, col 5, in walkSchema
    callback(schema,parent,state);
  File "/var/www-api/node_modules/oas-schema-walker/index.js", line 96, col 13, in walkSchema
    walkSchema(subSchema,schema,state,callback);
  File "/var/www-api/node_modules/oas-schema-walker/index.js", line 64, col 9, in walkSchema
    walkSchema(schema.items,schema,state,callback);
  File "/var/www-api/node_modules/oas-schema-walker/index.js", line 82, col 13, in Object.walkSchema
    walkSchema(subSchema,schema,state,callback);
```

## Fix

Fix does not affect any existing use case and only aims to avoid TypeError in certain case by checking type to be `string` before accessing string-related prototype function.